### PR TITLE
Update gvm-lsc-deb-creator

### DIFF
--- a/tools/gvm-lsc-deb-creator
+++ b/tools/gvm-lsc-deb-creator
@@ -162,9 +162,7 @@ COPYRIGHT_FILE="${DOC_DATA_DIR}/copyright"
 } > "${COPYRIGHT_FILE}"
 
 # Create data archive
-cd "${DATA_DIR}"
-tar -C "${DATA_DIR}" -z -cf "../data.tar.gz" "${HOME_SUBDIR}" "${DOC_SUBDIR}"
-
+tar -P -z -cf "${TEMP_DIR}/data.tar.gz" "${PACKAGE_BASE_DIR}/${HOME_DATA_SUBDIR}" "${PACKAGE_BASE_DIR}/${DOC_DATA_SUBDIR}"
 
 #
 # Create control files


### PR DESCRIPTION
Fixing issues with tar by correcting paths required to create the data archive before compiling the .deb.
This is caused by tar commands' inability to traverse output directory path to the desired output path
which results in a failed build of the .deb package and a 0-byte .deb package.