### PR TITLE
Update template.nsis

### DIFF
--- a/tools/template.nsis
+++ b/tools/template.nsis
@@ -65,9 +65,9 @@ Section
   ; Create user and add it to the Administrators group
   DetailPrint `Creating user ${__USERNAME__}`
   SetDetailsPrint none
-  ExecWait `cmd /C net user ${__USERNAME__} "${__PASSWORD__}" /add /active:yes`
+  ExecWait 'cmd /C net user ${__USERNAME__} "${__PASSWORD__}" /add /active:yes'
   SetDetailsPrint both
-  ExecWait `cmd /C net localgroup $ADMINGROUPNAME %COMPUTERNAME%\${__USERNAME__} /add`
+  ExecWait 'cmd /C net localgroup $ADMINGROUPNAME %COMPUTERNAME%\${__USERNAME__} /add'
 
   ; Remove temporary files for localized admin group names
   Delete $TEMPVBSFILE
@@ -81,7 +81,7 @@ SectionEnd
 ; Uninstaller section
 Section Uninstall
 
-  ExecWait "net user ${__USERNAME__} /delete"
+  ExecWait 'net user ${__USERNAME__} /delete'
 
   ; Display message that everything seems to be fine
   MessageBox MB_OK "A user has been removed. You can now safely remove the uninstaller from your Desktop."


### PR DESCRIPTION
Fixing a bug in the EXE credential creator resulting from a syntax error in the ExecWait commands.

The error reported in the logs is:

```
lsc_user_exe_create: stderr: ExecWait expects 1-2 parameters, got 4.
Usage: ExecWait command_line [$(user_var: return value)]
Error in script "/tmp/lsc_user_exe_create_RQTLze/script.nsis" on line 68 -- aborting creation process
credential_iterator_exe: Failed to create EXE
```

This was discovered to be a syntax error using backticks in the ExecWait commands that resulted in incorrect parsing of the commands.