### PR TITLE
Update gvm-lsc-rpm-creator

### DIFF
--- a/tools/gvm-lsc-rpm-creator
+++ b/tools/gvm-lsc-rpm-creator
@@ -130,6 +130,8 @@ SPEC_FILE="${SPEC_DIR}/${PACKAGE_NAME_VERSION}.spec"
   echo "BuildArch: noarch"
   # Put output in current directory
   echo "%define _rpmdir %(pwd)"
+  # Set _topdir
+  echo "%define _topdir ${TEMP_DIR}"
 
   # Create description section
   echo "%description"


### PR DESCRIPTION
Setting  "_topdir" in the rpmbuild config is required to prevent the rpmbuild process from attempting to access the gvm user's home directory, (which does not exist) resulting in a 0-byte user credential creator .rpm package.

This has been tested on Ubuntu 22.04, Kali 2023.1, and CentOS 9 Stream.